### PR TITLE
feat(manifest): add initial schema definitions for configuration classes

### DIFF
--- a/app/xulcan/manifest/schema.py
+++ b/app/xulcan/manifest/schema.py
@@ -1,0 +1,61 @@
+from xulcan.core.primitives import (
+    ImmutableRecord,
+    MachineID,
+    SemanticVersion,
+    JsonDict,
+)
+from pydantic import Field
+
+
+class LedgerConfig(ImmutableRecord):
+    driver: MachineID = "memory"
+    params: JsonDict = Field(default_factory=dict)
+
+
+class StateStoreConfig(ImmutableRecord):
+    driver: MachineID = "memory"
+    params: JsonDict = Field(default_factory=dict)
+
+
+class EventBusConfig(ImmutableRecord):
+    driver: MachineID = "memory"
+    params: JsonDict = Field(default_factory=dict)
+
+
+class VaultConfig(ImmutableRecord):
+    driver: MachineID = "env"
+    params: JsonDict = Field(default_factory=dict)
+
+
+class KernelConfig(ImmutableRecord):
+    ledger: LedgerConfig = Field(default_factory=LedgerConfig)
+    state_store: StateStoreConfig = Field(default_factory=StateStoreConfig)
+    event_bus: EventBusConfig = Field(default_factory=EventBusConfig)
+    vault: VaultConfig = Field(default_factory=VaultConfig)
+
+
+class LLMInstanceConfig(ImmutableRecord):
+    driver: MachineID
+    model: str
+    params: JsonDict = Field(default_factory=dict)
+
+
+class LLMConfig(ImmutableRecord):
+    default: MachineID
+    instances: dict[MachineID, LLMInstanceConfig]
+
+
+class ProvidersConfig(ImmutableRecord):
+    llm: LLMConfig
+
+
+class BlueprintsConfig(ImmutableRecord):
+    paths: list[str] = Field(default_factory=list)
+    autoload: bool = False
+
+
+class InfraprintManifest(ImmutableRecord):
+    version: SemanticVersion
+    kernel: KernelConfig = Field(default_factory=KernelConfig)
+    providers: ProvidersConfig
+    blueprints: BlueprintsConfig = Field(default_factory=BlueprintsConfig)


### PR DESCRIPTION
## 📋 Description

Implements `InfraprintManifest` — the formal infrastructure ontology for Xulcan's runtime topology (closes #24).

This schema defines the declarative configuration layer for infrastructure decisions:
- **Kernel components:** ledger, state_store, event_bus, vault adapters
- **Provider routing:** LLM driver selection and instance management  
- **Blueprint discovery:** paths and autoload configuration
- **Version pinning:** semantic versioning for manifest compatibility

All models extend `ImmutableRecord` and use semantic types (`MachineID`, `SemanticVersion`, `JsonDict`) consistent with `AgentBlueprint`. The schema is defined but not consumed — ready for `assembler.py` to interpret in future work.

**Files Created:**
- `xulcan/manifest/__init__.py` (empty module marker)
- schema.py (full schema with 8 model classes)

**Canonical MVP YAML validates cleanly** against the schema with all defaults working correctly.

---

## 🛠 Type of Change
- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🏗️ Infrastructure / Docker / Config
- [ ] 📚 Documentation
- [ ] 🧪 Tests

---

## 🧪 Testing & Verification
- [x] **Standalone Validation:** Canonical `infraprint.yml` successfully parses and validates against `InfraprintManifest` schema
- [x] **Type Safety:** All `driver` fields validate as `MachineID`, `version` as `SemanticVersion`, `params` as `JsonDict` with immutable defaults
- [x] **No Behavioral Impact:** Zero imports from `manifest/` in existing codebase; system runtime unchanged
- [x] **Import Test:** Module imports cleanly with all required primitives available

---

## ✅ Checklist
- [x] Code follows project style guidelines (Pydantic patterns match schema.py)
- [x] Self-reviewed: all models extend `ImmutableRecord`, semantic types used consistently
- [x] Schema is self-documenting; field validation enforces constraints
- [x] No new warnings generated
- [x] Zero persistence layer changes (Postgres/Redis unaffected)
- [x] All acceptance criteria met:
  - ✓ schema.py exists with full `InfraprintManifest` model
  - ✓ All models extend `ImmutableRecord`
  - ✓ `driver` fields typed as `MachineID` (no `provider` ambiguity)
  - ✓ `version` typed as `SemanticVersion`
  - ✓ `params` use `JsonDict` with `Field(default_factory=dict)` — no mutable defaults
  - ✓ `default_factory` patterns follow Pydantic convention from `blueprint/`
  - ✓ All kernel infrastructure components representable
  - ✓ Canonical YAML validates cleanly in standalone test
  - ✓ No imports from `manifest/` elsewhere (defined, not consumed)
  - ✓ Zero behavioral changes to running system