### PR TITLE
feat(runtime): implement ManifestResolver and ResolvedInfrastructure. close #28

### DIFF
--- a/app/xulcan/manifest/__init__.py
+++ b/app/xulcan/manifest/__init__.py
@@ -1,0 +1,1 @@
+from xulcan.manifest.schema import InfraprintManifest

--- a/app/xulcan/runtime/__init__.py
+++ b/app/xulcan/runtime/__init__.py
@@ -1,0 +1,2 @@
+from xulcan.runtime.topology import ResolvedInfrastructure
+from xulcan.runtime.resolver import ManifestResolver

--- a/app/xulcan/runtime/resolver.py
+++ b/app/xulcan/runtime/resolver.py
@@ -1,0 +1,166 @@
+# xulcan/runtime/resolver.py
+"""ManifestResolver — Stage-1 of Xulcan's runtime materialization pipeline.
+
+Reads an InfraprintManifest and produces a ResolvedInfrastructure.
+This is the first async-native component in the boot pipeline.
+"""
+
+from __future__ import annotations
+
+import yaml
+import logging
+from pathlib import Path
+from typing import Union, Any
+
+from xulcan.manifest.schema import InfraprintManifest
+from xulcan.registry.container import RegistryContainer
+from xulcan.runtime.topology import ResolvedInfrastructure
+from xulcan.llm.base import BaseLLMAdapter
+
+logger = logging.getLogger("xulcan.runtime.resolver")
+
+
+class ManifestResolver:
+    """Reads an InfraprintManifest and materializes it into ResolvedInfrastructure.
+
+    Responsibilities:
+        1. Parse and validate the YAML manifest.
+        2. Instantiate vault first — the credential source for all LLM instances.
+        3. Resolve credentials from vault before adapter construction.
+        4. Instantiate all infrastructure adapters.
+        5. Return ResolvedInfrastructure for the assembler.
+
+    Does NOT:
+        - Build ProtoKernel (Issue 4)
+        - Load AgentBlueprints (Issue 4)
+        - Wire tool executors (Issue 4)
+
+    Usage:
+        container = RegistryContainer()
+        bootstrap_registries(container)
+
+        resolver = ManifestResolver(container)
+        infra = await resolver.load("infraprint.yml")
+    """
+
+    def __init__(self, container: RegistryContainer):
+        self._container = container
+
+    async def load(self, path: Union[str, Path]) -> ResolvedInfrastructure:
+        """Parse and resolve an infraprint manifest from disk.
+
+        Args:
+            path: Path to the infraprint.yml file.
+
+        Returns:
+            ResolvedInfrastructure with all adapters instantiated.
+
+        Raises:
+            FileNotFoundError: If the manifest file does not exist.
+            ValueError: If manifest fails schema validation or a required
+                        adapter is not registered in the container.
+        """
+        manifest = self._parse(path)
+        return await self._resolve(manifest)
+
+    async def resolve_data(self, data: dict[str, Any]) -> ResolvedInfrastructure:
+        """Resolve from an already-parsed dict.
+
+        Skips filesystem IO entirely. Intended for test isolation and
+        programmatic manifest construction.
+
+        Args:
+            data: Raw dict conforming to InfraprintManifest schema.
+
+        Returns:
+            ResolvedInfrastructure with all adapters instantiated.
+        """
+        manifest = InfraprintManifest.model_validate(data)
+        return await self._resolve(manifest)
+
+    # ── Private ───────────────────────────────────────────────────────────
+
+    def _parse(self, path: Union[str, Path]) -> InfraprintManifest:
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Infraprint manifest not found: {path}")
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not data:
+            raise ValueError(f"Infraprint manifest is empty: {path}")
+        return InfraprintManifest.model_validate(data)
+
+    async def _resolve(self, manifest: InfraprintManifest) -> ResolvedInfrastructure:
+        # ── 1. Vault first ────────────────────────────────────────────────
+        # Must be instantiated before any other adapter.
+        # It is the credential source for all LLM instances.
+        vault = self._container.vault.build(
+            manifest.kernel.vault.driver,
+            dict(manifest.kernel.vault.params or {})
+        )
+        logger.debug(f"✓ Vault: driver={manifest.kernel.vault.driver}")
+
+        # ── 2. LLM instances ──────────────────────────────────────────────
+        # Credentials are resolved from vault BEFORE calling registry.build().
+        # No asyncio bridges inside ProviderRegistry — IO stays here.
+        #
+        # Vault key convention: {driver}_api_key
+        #   "gemini"    → vault.get_secret("gemini_api_key")    → GEMINI_API_KEY
+        #   "anthropic" → vault.get_secret("anthropic_api_key") → ANTHROPIC_API_KEY
+        #
+        # Override via LLMInstanceConfig.params["vault_key"] when the env var
+        # does not follow the standard pattern.
+        # ── 2. Remaining infrastructure ───────────────────────────────────
+        # Build the EventBus before the Ledger because the Ledger may emit
+        # firehose events through the bus during runtime.
+        event_bus = self._container.event_bus.build(
+            manifest.kernel.event_bus.driver,
+            dict(manifest.kernel.event_bus.params or {})
+        )
+        logger.debug(f"✓ EventBus: driver={manifest.kernel.event_bus.driver}")
+
+        ledger = self._container.ledger.build(
+            manifest.kernel.ledger.driver,
+            {**dict(manifest.kernel.ledger.params or {}), "event_bus": event_bus}
+        )
+        state_store = self._container.state_store.build(
+            manifest.kernel.state_store.driver,
+            dict(manifest.kernel.state_store.params or {})
+        )
+
+        logger.debug(
+            f"✓ Infrastructure: "
+            f"ledger={manifest.kernel.ledger.driver} "
+            f"bus={manifest.kernel.event_bus.driver} "
+            f"state_store={manifest.kernel.state_store.driver}"
+        )
+
+        llm_instances: dict[str, BaseLLMAdapter] = {}
+
+        for name, cfg in manifest.providers.llm.instances.items():
+            params = {"model_name": cfg.model, **dict(cfg.params or {})}
+
+            if "api_key" not in params:
+                vault_key = params.pop("vault_key", f"{cfg.driver}_api_key")
+                api_key = await vault.get_secret(vault_key)
+                if api_key:
+                    params["api_key"] = api_key
+                else:
+                    logger.warning(
+                        f"⚠ No secret found for LLM instance '{name}' "
+                        f"(driver={cfg.driver}, vault_key={vault_key}). "
+                        f"Adapter may fail at inference time."
+                    )
+
+            llm_instances[name] = self._container.llm.build(cfg.driver, params)
+            logger.debug(f"✓ LLM: {name} (driver={cfg.driver})")
+
+        return ResolvedInfrastructure(
+            manifest=manifest,
+            llm_instances=llm_instances,
+            default_llm=manifest.providers.llm.default,
+            ledger=ledger,
+            event_bus=event_bus,
+            state_store=state_store,
+            vault=vault,
+        )

--- a/app/xulcan/runtime/topology.py
+++ b/app/xulcan/runtime/topology.py
@@ -1,0 +1,39 @@
+# xulcan/runtime/topology.py
+"""Stage-1 runtime topology objects.
+
+Shared data layer between ManifestResolver and RuntimeAssembler.
+Objects here represent infrastructure materialized from manifest resolution,
+not the full runtime — that emerges in Issue 4 (ROADMAP).
+"""
+
+from __future__ import annotations
+
+from xulcan.core.primitives import ImmutableRecord
+from xulcan.manifest.schema import InfraprintManifest
+from xulcan.ledger.base import BaseLedgerAdapter
+from xulcan.bus.base import BaseEventBus
+from xulcan.memory.state.base import BaseStateStore
+from xulcan.memory.vault.base import BaseVaultStore
+from xulcan.llm.base import BaseLLMAdapter
+
+
+class ResolvedInfrastructure(ImmutableRecord):
+    """Stage-1 runtime topology — infrastructure materialized from manifest.
+
+    Boundary object between ManifestResolver and RuntimeAssembler.
+    Contains fully instantiated adapters, not classes or registry references.
+    Carries the original manifest to avoid reparsing in downstream stages.
+
+    This is Stage-1 topology, not the final RuntimeContext.
+    The assembler extends this in Issue 4 with tool routing, blueprint
+    loading, and execution surfaces before handing it to ProtoKernel.
+    """
+    model_config = {"arbitrary_types_allowed": True}
+
+    manifest: InfraprintManifest
+    llm_instances: dict[str, BaseLLMAdapter]
+    default_llm: str
+    ledger: BaseLedgerAdapter
+    event_bus: BaseEventBus
+    state_store: BaseStateStore
+    vault: BaseVaultStore

--- a/tests/xulcan/runtime/test_resolver.py
+++ b/tests/xulcan/runtime/test_resolver.py
@@ -1,0 +1,113 @@
+"""Tests for ManifestResolver and ResolvedInfrastructure."""
+
+import pytest
+from xulcan.runtime.resolver import ManifestResolver
+from xulcan.runtime.topology import ResolvedInfrastructure
+from xulcan.registry.container import RegistryContainer
+from xulcan.registry import bootstrap_registries
+
+
+@pytest.fixture
+def container() -> RegistryContainer:
+    """RegistryContainer with all built-in adapters registered."""
+    container = RegistryContainer()
+    bootstrap_registries(container)
+    return container
+
+
+@pytest.fixture
+def canonical_manifest_data() -> dict:
+    """Canonical infraprint.yml data from Issue 1."""
+    return {
+        "version": "1.0.0",
+        "kernel": {
+            "vault": {"driver": "memory"},
+            "ledger": {"driver": "memory"},
+            "event_bus": {"driver": "memory"},
+            "state_store": {"driver": "memory"}
+        },
+        "providers": {
+            "llm": {
+                "default": "gemini",
+                "instances": {
+                    "gemini": {
+                        "driver": "gemini",
+                        "model": "gemini-2.5-flash"
+                    },
+                    "anthropic": {
+                        "driver": "anthropic",
+                        "model": "claude-3-5-sonnet-20241022"
+                    }
+                }
+            }
+        },
+        "blueprints": {
+            "paths": [],
+            "autoload": False
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_data_canonical_manifest(container: RegistryContainer, canonical_manifest_data: dict):
+    """Test end-to-end resolution of canonical infraprint.yml using MemoryVaultStore with pre-loaded secrets."""
+    # Pre-load secrets into vault (simulating env vars or external vault)
+    vault_secrets = {
+        "gemini_api_key": "test_gemini_key",
+        "anthropic_api_key": "test_anthropic_key"
+    }
+    # Override the vault params to include initial secrets
+    canonical_manifest_data["kernel"]["vault"]["params"] = {"initial_secrets": vault_secrets}
+
+    resolver = ManifestResolver(container)
+    infra = await resolver.resolve_data(canonical_manifest_data)
+
+    # Verify ResolvedInfrastructure structure
+    assert isinstance(infra, ResolvedInfrastructure)
+    assert infra.manifest.version == "1.0.0"
+    assert infra.default_llm == "gemini"
+
+    # Verify LLM instances
+    assert "gemini" in infra.llm_instances
+    assert "anthropic" in infra.llm_instances
+    assert len(infra.llm_instances) == 2
+
+    # Verify infrastructure adapters
+    assert infra.vault is not None
+    assert infra.ledger is not None
+    assert infra.event_bus is not None
+    assert infra.state_store is not None
+
+
+@pytest.mark.asyncio
+async def test_missing_vault_key_logs_warning(container: RegistryContainer, canonical_manifest_data: dict, caplog):
+    """Test that missing vault key logs a warning but does not raise."""
+    # No secrets pre-loaded
+    canonical_manifest_data["kernel"]["vault"]["params"] = {}
+
+    resolver = ManifestResolver(container)
+    infra = await resolver.resolve_data(canonical_manifest_data)
+
+    # Should still succeed but with warnings
+    assert isinstance(infra, ResolvedInfrastructure)
+    assert "No secret found for LLM instance" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_custom_vault_key_override(container: RegistryContainer, canonical_manifest_data: dict):
+    """Test vault_key override in LLMInstanceConfig.params."""
+    vault_secrets = {
+        "custom_gemini_key": "test_gemini_key",
+        "anthropic_api_key": "test_anthropic_key"
+    }
+    canonical_manifest_data["kernel"]["vault"]["params"] = {"initial_secrets": vault_secrets}
+    # Override vault_key for gemini
+    canonical_manifest_data["providers"]["llm"]["instances"]["gemini"]["params"] = {
+        "vault_key": "custom_gemini_key"
+    }
+
+    resolver = ManifestResolver(container)
+    infra = await resolver.resolve_data(canonical_manifest_data)
+
+    assert isinstance(infra, ResolvedInfrastructure)
+    assert "gemini" in infra.llm_instances


### PR DESCRIPTION
### 📋 Description
Implements the new `xulcan/runtime/` materialization layer and updates `ManifestResolver` so runtime infrastructure is built in the correct dependency order.

Key changes:
- Added `xulcan/runtime/topology.py` with `ResolvedInfrastructure`
- Added resolver.py with `ManifestResolver`
- Added __init__.py
- Updated __init__.py to keep the manifest layer pure
- Materialization order in `ManifestResolver._resolve()` now follows:
  - `vault`
  - `event_bus`
  - `ledger`
  - `state_store`
  - `llm_instances`
- Preserved legacy `CredentialProxy`/runtime.py behavior

### 🛠 Type of Change
- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🏗️ Infrastructure / Docker / Config
- [ ] 📚 Documentation
- [x] 🧪 Tests

### 🧪 Testing & Verification
- [ ] **Unit Tests:** Ran targeted `python -m py_compile resolver.py tests/xulcan/runtime/test_resolver.py`; full suite blocked by missing `structlog` in this environment.
- [ ] **Docker Build:** Not run
- [x] **Manual Verification:** Direct manifest resolution with `ManifestResolver.resolve_data(...)` using `MemoryVaultStore` secrets and `RegistryContainer` bootstrap

### ✅ Checklist
- [x] My code follows the project's style guidelines where applicable
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas
- [ ] I have updated the documentation (README, API docs) if needed
- [x] My changes generate no new syntax warnings
- [ ] I have verified data persistence (Postgres/Redis) is not broken (not applicable for this runtime-only change)