### PR TITLE
feat(runtime): add RuntimeAssembler and RuntimeContext.

### DIFF
--- a/app/xulcan/runtime/__init__.py
+++ b/app/xulcan/runtime/__init__.py
@@ -1,2 +1,5 @@
 from xulcan.runtime.topology import ResolvedInfrastructure
 from xulcan.runtime.resolver import ManifestResolver
+from xulcan.runtime.assembler import RuntimeAssembler
+from xulcan.runtime.context import RuntimeContext
+from xulcan.runtime.llm_registry_adapter import RuntimeLLMRegistryAdapter

--- a/app/xulcan/runtime/assembler.py
+++ b/app/xulcan/runtime/assembler.py
@@ -1,0 +1,134 @@
+# xulcan/runtime/assembler.py
+"""RuntimeAssembler — Stage-2 of Xulcan's runtime materialization pipeline."""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Optional
+
+from xulcan.runtime.topology import ResolvedInfrastructure
+from xulcan.runtime.context import RuntimeContext
+from xulcan.runtime.llm_registry_adapter import RuntimeLLMRegistryAdapter
+from xulcan.registry.container import RegistryContainer
+
+from xulcan.kernel.environment import SystemEnvironment
+from xulcan.kernel.runtime import ProtoKernel
+from xulcan.llm.executor import LLMExecutor
+
+from xulcan.tools.executors.local import LocalPythonExecutor
+from xulcan.tools.executors.agent import SubAgentExecutor
+from xulcan.tools.router import ToolRouterExecutor
+from xulcan.tools.executors.sandbox.docker import DockerProvider
+from xulcan.tools.executors.sandbox.executor import SandboxExecutor
+
+logger = logging.getLogger("xulcan.runtime.assembler")
+
+
+class RuntimeAssembler:
+    """Wires the execution graph and constructs the executable runtime.
+
+    Receives Stage-1 topology (ResolvedInfrastructure) and governance
+    registries (RegistryContainer), produces RuntimeContext.
+
+    Wiring order:
+        1. SystemEnvironment  (requires state_store, vault, event_bus)
+        2. LLM surface        (RuntimeLLMRegistryAdapter → LLMExecutor)
+        3. Tool executors     (each receives environment)
+        4. ToolRouterExecutor (receives environment; routes populated later)
+        5. SandboxExecutor    (optional — graceful on Docker absence)
+        6. ProtoKernel        (receives all surfaces + governance registries)
+        7. Post-construction  (SubAgentExecutor.bind_kernel)
+
+    Note on tool routing:
+        ToolRouterExecutor._routing_table is empty after assembly.
+        Routes are registered by the public API (@tool, add_agent,
+        enable_sandbox) in Issue 5. The assembler builds capabilities,
+        not routes.
+    """
+
+    def __init__(
+        self,
+        infrastructure: ResolvedInfrastructure,
+        registries: RegistryContainer,
+    ):
+        self._infrastructure = infrastructure
+        self._registries = registries
+
+    async def assemble(self) -> RuntimeContext:
+        infra = self._infrastructure
+
+        # ── 1. SystemEnvironment ─────────────────────────────────────────
+        # Central shared context for all execution surfaces.
+        # Required by: context strategies, tool executors, kernel.
+        environment = SystemEnvironment(
+            state_store=infra.state_store,
+            vault_store=infra.vault,
+            event_bus=infra.event_bus,
+            workspace_id=None,
+        )
+        logger.debug("✓ SystemEnvironment assembled")
+
+        # ── 2. LLM Execution Surface ─────────────────────────────────────
+        # RuntimeLLMRegistryAdapter bridges pre-instantiated adapters
+        # to legacy registry.build() contract. LLMExecutor unchanged.
+        llm_registry_adapter = RuntimeLLMRegistryAdapter(infra.llm_instances)
+        llm_executor = LLMExecutor(registry=llm_registry_adapter)
+        logger.debug("✓ LLMExecutor assembled via RuntimeLLMRegistryAdapter")
+
+        # ── 3. Tool Executors ────────────────────────────────────────────
+        # Each executor receives environment for state/vault access.
+        # SubAgentExecutor receives kernel via post-construction binding.
+        local_executor = LocalPythonExecutor(environment=environment)
+        sub_agent_executor = SubAgentExecutor(environment=environment)
+        logger.debug("✓ LocalPythonExecutor and SubAgentExecutor assembled")
+
+        # ── 4. Tool Router ───────────────────────────────────────────────
+        # Routing table is empty here — populated by public API in Issue 5.
+        # The router is the execution surface the kernel calls.
+        tool_router = ToolRouterExecutor(environment=environment)
+        logger.debug("✓ ToolRouterExecutor assembled (routing table empty — populated by public API)")
+
+        # ── 5. Sandbox (optional) ────────────────────────────────────────
+        sandbox_executor: Optional[SandboxExecutor] = None
+        try:
+            sandbox_executor = SandboxExecutor(
+                provider=DockerProvider(),
+                environment=environment,
+            )
+            logger.debug("✓ SandboxExecutor assembled (Docker available)")
+        except Exception as e:
+            logger.warning(f"⚠ Docker unavailable — sandbox tools disabled: {e}")
+
+        # ── 6. ProtoKernel ───────────────────────────────────────────────
+        # Passive execution consumer. Receives all wired surfaces.
+        # Governance registries come from RegistryContainer.
+        kernel = ProtoKernel(
+            repository=infra.ledger,
+            llm_executor=llm_executor,
+            tool_executor=tool_router,
+            context_registry=self._registries.context,
+            bursar_registry=self._registries.bursar,
+            sentinel_registry=self._registries.sentinel,
+            human_gate_registry=self._registries.human_gate,
+            environment=environment,
+        )
+        logger.debug("✓ ProtoKernel assembled")
+
+        # ── 7. Post-Construction Cyclic Binding ──────────────────────────
+        # SubAgentExecutor needs kernel to spawn child runs.
+        # ProtoKernel needs tool_router which includes SubAgentExecutor.
+        # Both must be fully constructed before this binding.
+        sub_agent_executor.bind_kernel(kernel)
+        logger.debug("✓ SubAgentExecutor ← kernel binding complete")
+
+        return RuntimeContext(
+            infrastructure=infra,
+            environment=environment,
+            llm_executor=llm_executor,
+            tool_router=tool_router,
+            local_executor=local_executor,
+            sub_agent_executor=sub_agent_executor,
+            sandbox_executor=sandbox_executor,
+            kernel=kernel,
+        )

--- a/app/xulcan/runtime/context.py
+++ b/app/xulcan/runtime/context.py
@@ -1,0 +1,47 @@
+# xulcan/runtime/context.py
+"""RuntimeContext — fully assembled, executable runtime graph."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from xulcan.core.primitives import ImmutableRecord
+from xulcan.runtime.topology import ResolvedInfrastructure
+from xulcan.kernel.runtime import ProtoKernel
+from xulcan.kernel.environment import SystemEnvironment
+from xulcan.llm.executor import LLMExecutor
+from xulcan.tools.base import BaseToolExecutor
+
+
+class RuntimeContext(ImmutableRecord):
+    """Fully assembled runtime graph.
+
+    Produced by RuntimeAssembler. Final runtime boundary before
+    public API exposure in Xulcan (Issue 5).
+
+    This is NOT global state, NOT a singleton, NOT session memory.
+    One instance per Xulcan runtime.
+
+    Fields:
+        infrastructure:  Stage-1 topology from ManifestResolver.
+                         Includes original manifest for introspection.
+        environment:     SystemEnvironment wired with state_store, vault, event_bus.
+        llm_executor:    LLMExecutor backed by RuntimeLLMRegistryAdapter.
+        tool_router:     ToolRouterExecutor — assembled capability surface.
+                         Routes are empty at assembly time; populated by
+                         public API (@tool, add_agent, enable_sandbox) in Issue 5.
+        local_executor:  LocalPythonExecutor — exposed for tool registration.
+        sub_agent_executor: SubAgentExecutor — exposed for agent registration.
+        sandbox_executor:   SandboxExecutor or None if Docker unavailable.
+        kernel:          ProtoKernel — passive execution consumer.
+    """
+    model_config = {"arbitrary_types_allowed": True}
+
+    infrastructure: ResolvedInfrastructure
+    environment: SystemEnvironment
+    llm_executor: LLMExecutor
+    tool_router: BaseToolExecutor
+    local_executor: BaseToolExecutor
+    sub_agent_executor: BaseToolExecutor
+    sandbox_executor: Optional[BaseToolExecutor]
+    kernel: ProtoKernel

--- a/app/xulcan/runtime/llm_registry_adapter.py
+++ b/app/xulcan/runtime/llm_registry_adapter.py
@@ -1,0 +1,48 @@
+# xulcan/runtime/llm_registry_adapter.py
+"""Transitional compatibility bridge between topology-driven runtime and legacy LLMExecutor.
+
+Removed once LLMExecutor becomes topology-native in Issue 5+.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+
+from xulcan.llm.base import BaseLLMAdapter
+
+logger = logging.getLogger("xulcan.runtime.llm_registry_adapter")
+
+
+class RuntimeLLMRegistryAdapter:
+    """Exposes a registry-like .build() interface over already-instantiated LLM adapters.
+
+    LLMExecutor expects:
+        registry.build(provider_name, params) -> BaseLLMAdapter
+
+    ResolvedInfrastructure already contains:
+        llm_instances: dict[str, BaseLLMAdapter]
+
+    This bridge satisfies the LLMExecutor contract without modifying it.
+    params are intentionally ignored — adapters were configured at materialization time.
+
+    Transitional: disappears when LLMExecutor is refactored in Issue 5+.
+    """
+
+    def __init__(self, instances: dict[str, BaseLLMAdapter]):
+        self._instances = instances
+        logger.debug(
+            f"RuntimeLLMRegistryAdapter initialized: {list(instances.keys())}"
+        )
+
+    def build(self, name: str, params: dict[str, Any]) -> BaseLLMAdapter:
+        if name not in self._instances:
+            raise ValueError(
+                f"LLM instance '{name}' not found in runtime topology. "
+                f"Available: {list(self._instances.keys())}"
+            )
+        return self._instances[name]
+
+    @property
+    def available_providers(self) -> List[str]:
+        return list(self._instances.keys())


### PR DESCRIPTION
## 📋 Description
Extracted Xulcan's implicit runtime construction from `app.py` into a dedicated assembly layer.

Added:
- llm_registry_adapter.py
- context.py
- assembler.py
- exports in __init__.py

This creates a clear, deterministic runtime dependency graph:
- `ResolvedInfrastructure`
- `RuntimeAssembler`
- `RuntimeContext`
- `ProtoKernel`

It preserves legacy behavior by keeping `LLMExecutor` and `ProtoKernel` unchanged.

---

## 🛠 Type of Change
- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [x] ♻️ Refactor (no functional changes)
- [ ] 🏗️ Infrastructure / Docker / Config
- [ ] 📚 Documentation
- [ ] 🧪 Tests

---

## 🧪 Testing & Verification
- [ ] **Unit Tests:** Not executed in this session
- [ ] **Docker Build:** Not executed in this session
- [x] **Manual Verification:** Inspected file contents and confirmed the new runtime components import successfully

---

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas
- [ ] I have updated the documentation if needed
- [x] My changes generate no new warnings in the new files
- [ ] I have verified data persistence is not broken