### PR TITLE
feat: add LocalEnvVaultStore for environment-based secret management

### DIFF
--- a/app/xulcan/memory/vault/adapters/local_env.py
+++ b/app/xulcan/memory/vault/adapters/local_env.py
@@ -1,0 +1,70 @@
+"""Local OS Environment Vault Store implementation.
+
+Fetches secrets from:
+    1. Direct OS Environment variables (e.g. GEMINI_API_KEY).
+    2. Docker Secrets / File-based secrets (via the _FILE suffix convention).
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+from pathlib import Path
+
+from xulcan.memory.vault.base import BaseVaultStore
+
+logger = logging.getLogger("xulcan.vault.env")
+
+
+class LocalEnvVaultStore(BaseVaultStore):
+    """Vault Store for real-world local and containerized environments.
+    
+    This adapter is the standard for production deployments. It follows 
+    cloud-native patterns for secret injection.
+    
+    Resolution Strategy:
+        1. Look for environment variable: {KEY.upper()}
+        2. If not found, look for: {KEY.upper()}_FILE
+        3. If {KEY.upper()}_FILE exists, read the content of the file path it points to.
+    """
+
+    def __init__(self, **_kwargs) -> None:
+        # No requiere inicialización especial, todo viene del S.O.
+        pass
+
+    async def _get_secret_impl(self, key: str) -> str | None:
+        """Resolves the secret from the OS or filesystem."""
+        env_key = key.upper()
+        
+        # ── 1. Intento directo (Variable de Entorno) ─────────────────────
+        direct_value = os.getenv(env_key)
+        if direct_value:
+            return direct_value
+
+        # ── 2. Intento vía Docker Secret (Path en _FILE) ─────────────────
+        # Ejemplo: si busca GEMINI_API_KEY, mira si existe GEMINI_API_KEY_FILE
+        file_path_var = os.getenv(f"{env_key}_FILE")
+        
+        if file_path_var:
+            path = Path(file_path_var)
+            if path.exists() and path.is_file():
+                try:
+                    # Leer archivo, limpiar espacios/saltos de línea
+                    content = path.read_text(encoding="utf-8").strip()
+                    if content:
+                        logger.debug(f"🔐 Secret '{env_key}' loaded from file: {path}")
+                        return content
+                except Exception as e:
+                    logger.error(
+                        f"❌ Error reading secret file for '{env_key}' at {path}: {str(e)}"
+                    )
+        
+        return None
+
+    async def _set_secret_impl(self, key: str, value: str) -> None:
+        """Sets a secret in the current process environment.
+        
+        NOTE: This only affects the current running process, not the 
+        actual OS/Docker environment persistently.
+        """
+        os.environ[key.upper()] = value

--- a/app/xulcan/registry/bootstrap.py
+++ b/app/xulcan/registry/bootstrap.py
@@ -50,13 +50,14 @@ def bootstrap_registries(container: RegistryContainer) -> None:
 
     # ── State Store ───────────────────────────────────────────────────────
     from xulcan.memory.state.adapters.in_memory import MemoryStateStore
-
     container.state_store.register("memory", MemoryStateStore)
 
     # ── Vault ─────────────────────────────────────────────────────────────
     from xulcan.memory.vault.adapters.in_memory import MemoryVaultStore
+    from xulcan.memory.vault.adapters.local_env import LocalEnvVaultStore
 
     container.vault.register("memory", MemoryVaultStore)
+    container.vault.register("env", LocalEnvVaultStore)
 
     # ══════════════════════════════════════════════════════════════════════
     # 2. LLM ADAPTERS


### PR DESCRIPTION
## 📋 Description
**Issue #44 — Cloud-Native Vault & Docker Secrets Support**

Este PR formaliza la separación entre el almacenamiento de secretos en memoria y el entorno operativo real. Introduce el adaptador `LocalEnvVaultStore` para soportar de forma nativa variables de entorno y **Docker Secrets** (vía convención `_FILE`). 

**Cambios clave:**
- Creación de `LocalEnvVaultStore` en `xulcan/memory/vault/adapters/local_env.py`.
- Limpieza de `MemoryVaultStore` para ser 100% in-memory (ideal para testing unitario).
- Registro de ambos drivers en el `bootstrap_registries`.
- Actualización del `Xulcanfile` en la distribución Lattice para usar el driver `env`.

## 🛠 Type of Change
- [x] ✨ New feature (feat)
- [x] ♻️ Refactor (no functional changes)
- [x] 🏗️ Infrastructure / Docker / Config

## 🧪 Testing & Verification
- [x] **Docker Build:** Ejecutado `make dev` con el nuevo `Xulcanfile`.
- [x] **Manual Verification:** Se verificó en los logs que el sistema carga las API Keys de Gemini correctamente desde el entorno de Docker.
- [x] **Vault Logic:** Confirmada la resolución de secretos usando el sufijo `_FILE` para Docker Secrets montados en `/run/secrets/`.

## ✅ Checklist
- [x] Mi código sigue las guías de estilo (Black/Ruff).
- [x] He realizado una auto-revisión del código.
- [x] El `Xulcanfile` ahora es portable entre entornos locales y productivos.
- [x] Los tests unitarios ahora pueden usar el driver `memory` sin riesgo de colisiones con el entorno real.
