### PR TITLE
feat(manifest): introduce AppConfig namespace governance ontology

### DIFF
--- a/app/xulcan/manifest/schema.py
+++ b/app/xulcan/manifest/schema.py
@@ -1,10 +1,37 @@
+"""xulcan/manifest/schema.py — Infraprint Manifest schema definitions.
+
+Defines the declarative configuration structure for a Xulcan deployment.
+
+Architectural note on AppConfig:
+    AppConfig is intentionally minimal in v0.4.0. Its sole responsibility
+    is to establish namespace-level governance boundaries, enabling
+    hierarchical governance compilation downstream.
+
+    Future MAS/event-bus use cases (inter-app coordination, shared budgets,
+    event bus topology) may promote AppConfig into a full ontology with its
+    own `app.xul.yml` specification file. No speculative fields are introduced
+    in v0.4.0.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import Field
+from pydantic.functional_validators import BeforeValidator
+
+from xulcan.contracts import GovernanceConfig
 from xulcan.core.primitives import (
     ImmutableRecord,
     MachineID,
     SemanticVersion,
     JsonDict,
 )
-from pydantic import Field
+
+
+# ---------------------------------------------------------------------------
+# Kernel infrastructure configs
+# ---------------------------------------------------------------------------
 
 
 class LedgerConfig(ImmutableRecord):
@@ -34,6 +61,11 @@ class KernelConfig(ImmutableRecord):
     vault: VaultConfig = Field(default_factory=VaultConfig)
 
 
+# ---------------------------------------------------------------------------
+# LLM / provider configs
+# ---------------------------------------------------------------------------
+
+
 class LLMInstanceConfig(ImmutableRecord):
     driver: MachineID
     model: str
@@ -54,9 +86,93 @@ class BlueprintsConfig(ImmutableRecord):
     autoload: bool = False
 
 
+# ---------------------------------------------------------------------------
+# App ontology
+# ---------------------------------------------------------------------------
+
+
+class AppConfig(ImmutableRecord):
+    """Declarative container for a single App namespace.
+
+    In v0.4.0, AppConfig is intentionally minimal: its sole field beyond
+    ``path`` is optional ``governance``, establishing namespace-level
+    governance boundaries.
+
+    The ``path`` field maps directly to the on-disk folder that contains the
+    app's agents and tools, and doubles as the root namespace passed to the
+    ``tool_router``.
+
+    Future considerations (deferred to v0.5.0+):
+        - ``app.xul.yml`` specification files per app.
+        - App-level event bus topology.
+        - Inter-app coordination / IPC pipelines.
+        - App-level Sentinel / HumanGate governance.
+    """
+
+    path: str
+    governance: GovernanceConfig | None = None
+
+
+def _normalize_apps_list(v: Any) -> Any:
+    """Normalise legacy string app entries into AppConfig-compatible dicts.
+
+    Supports all three YAML forms simultaneously:
+
+    Legacy shorthand::
+
+        apps:
+          - sales
+          - support
+
+    Structured form::
+
+        apps:
+          - path: sales
+            governance:
+              budget: {strategy: enforced, params: {}}
+
+    Mixed form::
+
+        apps:
+          - sales
+          - path: quotations
+            governance: null
+
+    All entries are coerced into dicts before Pydantic validates them as
+    ``AppConfig``. Existing dicts / already-parsed ``AppConfig`` instances are
+    passed through unchanged.
+    """
+    if not isinstance(v, list):
+        return v
+
+    normalised: list[Any] = []
+    for item in v:
+        if isinstance(item, str):
+            normalised.append({"path": item, "governance": None})
+        else:
+            # dict or already-instantiated AppConfig — pass through
+            normalised.append(item)
+    return normalised
+
+
+# ---------------------------------------------------------------------------
+# Top-level manifest
+# ---------------------------------------------------------------------------
+
+
 class InfraprintManifest(ImmutableRecord):
+    """Top-level Infraprint manifest (xulcan.yml / Xulcanfile).
+
+    ``apps`` accepts legacy string shorthand, structured ``AppConfig``
+    dictionaries, and mixed lists — all normalised internally into
+    ``list[AppConfig]`` before any further processing.
+    """
+
     version: SemanticVersion
     kernel: KernelConfig = Field(default_factory=KernelConfig)
     providers: ProvidersConfig
     blueprints: BlueprintsConfig = Field(default_factory=BlueprintsConfig)
-    apps: list[str] = Field(default_factory=list)
+    apps: Annotated[
+        list[AppConfig],
+        BeforeValidator(_normalize_apps_list),
+    ] = Field(default_factory=list)

--- a/app/xulcan/runtime/loaders/app_discovery.py
+++ b/app/xulcan/runtime/loaders/app_discovery.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from xulcan.manifest.schema import AppConfig
 from xulcan.runtime.loaders.blueprint_loader import BlueprintLoader
 
 if TYPE_CHECKING:
@@ -18,40 +19,87 @@ logger = logging.getLogger("xulcan.runtime.loaders.app_discovery")
 
 
 class AppDiscoveryEngine:
-    """Discovers apps from disk and registers namespaces, agents, and tools."""
+    """Discovers apps from disk and registers namespaces, agents, and tools.
+
+    Each ``AppConfig`` entry in the manifest is resolved to an on-disk
+    directory.  The engine loads agents (YAML blueprints) and tools (Python
+    modules) found inside that directory and registers them under the app's
+    namespace.
+
+    ``discover_all`` returns the resolved ``AppConfig`` objects — including
+    any governance metadata — so the ``RuntimeAssembler`` can forward them
+    to the ``GovernanceResolver`` without re-parsing the manifest.
+    """
 
     def __init__(self, client: Xulcan):
         self._client = client
 
-    async def discover_all(self, app_paths: list[str], base_dir: str | None = None) -> None:
-        if not app_paths:
-            return
+    async def discover_all(
+        self,
+        apps: list[AppConfig],
+        base_dir: str | None = None,
+    ) -> list[AppConfig]:
+        """Discover and register all app namespaces.
+
+        Args:
+            apps: Resolved ``AppConfig`` objects from the manifest. Legacy
+                string entries will have already been normalised to
+                ``AppConfig(path=..., governance=None)`` by the manifest
+                parser.
+            base_dir: Base directory used to resolve relative ``path``
+                values.  Defaults to the current working directory.
+
+        Returns:
+            The same ``AppConfig`` objects, in discovery order, including
+            their governance metadata.  The ``RuntimeAssembler`` should pass
+            this list to the ``GovernanceResolver`` so app-level governance
+            is compiled centrally without re-parsing the manifest.
+        """
+        if not apps:
+            return []
 
         base_dir_path = Path(base_dir) if base_dir else Path.cwd()
-        resolved_paths = [
-            Path(path) if Path(path).is_absolute() else base_dir_path / path
-            for path in app_paths
-        ]
+        resolved: list[AppConfig] = []
 
-        for path in resolved_paths:
-            await self._discover_app(path)
+        for app_config in apps:
+            app_path = Path(app_config.path)
+            app_root = (
+                app_path
+                if app_path.is_absolute()
+                else base_dir_path / app_path
+            )
+            await self._discover_app(app_root, app_config)
+            resolved.append(app_config)
 
-    async def _discover_app(self, app_root: Path) -> None:
+        return resolved
+
+    async def _discover_app(self, app_root: Path, app_config: AppConfig) -> None:
         app_root = app_root.resolve()
         if not app_root.exists():
             raise FileNotFoundError(f"App folder not found: {app_root}")
         if not app_root.is_dir():
             raise ValueError(f"App path is not a directory: {app_root}")
 
+        # The namespace is the folder name, which equals app_config.path for
+        # simple (non-nested) paths and is the terminal component for nested
+        # ones.  This preserves backward-compatible namespace semantics while
+        # allowing the full app_config (including governance) to travel with
+        # the discovered namespace.
         namespace = app_root.name
-        logger.info("📦 Discovering app namespace '%s' at %s", namespace, app_root)
+        logger.info(
+            "📦 Discovering app namespace '%s' at %s (governance=%s)",
+            namespace,
+            app_root,
+            app_config.governance,
+        )
 
         blueprint_files = self._collect_blueprint_files(app_root)
         tool_files = self._collect_tool_files(app_root / "tools")
 
         if not blueprint_files and not tool_files:
             raise ValueError(
-                f"App folder '{app_root}' must contain at least one agent YAML or one tool Python file."
+                f"App folder '{app_root}' must contain at least one agent YAML "
+                "or one tool Python file."
             )
 
         for blueprint_path in blueprint_files:
@@ -78,7 +126,7 @@ class AppDiscoveryEngine:
 
         return sorted(
             [path for path in tools_root.rglob("*.py") if path.name != "__init__.py"],
-            key=lambda p: str(p)
+            key=lambda p: str(p),
         )
 
     def _load_blueprint(self, blueprint_path: Path, namespace: str, app_root: Path) -> Any:
@@ -89,14 +137,16 @@ class AppDiscoveryEngine:
             raise ValueError(f"Blueprint file is empty: {blueprint_path}")
 
         if not isinstance(raw_data, dict):
-            raise ValueError(f"Invalid blueprint content in {blueprint_path}. Expected a YAML mapping.")
+            raise ValueError(
+                f"Invalid blueprint content in {blueprint_path}. Expected a YAML mapping."
+            )
 
         if not raw_data.get("id"):
             raw_data["id"] = derived_id
         elif raw_data["id"] != derived_id:
             raise ValueError(
-                f"Blueprint ID mismatch for '{blueprint_path}': declared id '{raw_data['id']}' "
-                f"does not match inferred app id '{derived_id}'."
+                f"Blueprint ID mismatch for '{blueprint_path}': declared id "
+                f"'{raw_data['id']}' does not match inferred app id '{derived_id}'."
             )
 
         blueprint = BlueprintLoader.from_dict(raw_data)


### PR DESCRIPTION

## 📋 Description

```text id="s9b4ef"
Introduces `AppConfig` as the formal runtime ontology for namespace-level
application boundaries inside Xulcan.

This PR:
- adds a minimal `AppConfig` structure to the manifest layer
- introduces governance-aware app declarations
- preserves backwards compatibility with legacy string app entries
- supports mixed YAML declaration styles
- normalizes all app definitions into unified runtime objects
- propagates app governance metadata through AppDiscoveryEngine
- exposes resolved AppConfig objects to the RuntimeAssembler

After this refactor:
- Apps become explicit operational governance boundaries
- runtime assembly gains deterministic access to app-level metadata
- hierarchical governance compilation becomes possible
- future MAS/event-bus expansion gains a stable ontology foundation

This intentionally avoids speculative v0.5+ features such as:
- app.xul.yml files
- inter-app orchestration
- event bus topologies
- app-level Sentinel/HumanGate policies
```

---

## 🛠 Type of Change

```text id="q6v2jx"
[x] ✨ New feature (feat)
[x] ♻️ Refactor (no functional changes)
```

Yo marcaría ambos porque:

* sí introduces una nueva runtime ontology (`AppConfig`)
* pero también refactorizas el manifest/discovery pipeline

---

## 🧪 Testing & Verification

```text id="d4wy7u"
- [ ] Unit Tests: Pending alpha stabilization.
- [ ] Docker Build
- [x] Manual Verification:
      - Verified legacy string app declarations parse successfully.
      - Verified structured AppConfig YAML declarations parse correctly.
      - Verified mixed app declaration formats normalize without errors.
      - Verified AppDiscoveryEngine preserves app namespace paths.
      - Verified governance metadata propagates to runtime assembly.
      - Verified RuntimeAssembler receives resolved AppConfig objects.
      - Verified no circular import regressions introduced.
      - Verified runtime initialization succeeds after manifest normalization.
```
