### PR TITLE
fix(core): remove deleted economics symbols from core/__init__.py

### DIFF
--- a/app/xulcan/core/__init__.py
+++ b/app/xulcan/core/__init__.py
@@ -16,10 +16,7 @@ from .primitives import (
 )
 
 from .economics import (
-    UsageStats,
-    BudgetConfig,
-    BudgetStrategy,
-    BudgetExceededError
+    UsageStats
 )
 
 __all__ =[
@@ -35,8 +32,5 @@ __all__ =[
     "SafeURL",
     "Base64Data",
     "MimeType",
-    "UsageStats",
-    "BudgetConfig",
-    "BudgetStrategy",
-    "BudgetExceededError",
+    "UsageStats"
 ]


### PR DESCRIPTION
## 📋 Description

Completes the cleanup left incomplete after the Issue #49 Bursar Refactor. `BudgetConfig`, `BudgetStrategy`, and `BudgetExceededError` were successfully removed from `core/economics.py`, but their re-exports in `core/__init__.py` were never updated, causing a boot-time `ImportError` that crashed the kernel before uvicorn could even start.

This PR removes the stale symbol references from `core/__init__.py` and audits any other import sites across the codebase that still reference the deleted names.

Fixes #49

## 🛠 Type of Change

- [x] 🐛 Bug fix (fix)

## 🧪 Testing & Verification

- [ ] **Unit Tests:** Ran `./scripts/test.sh` successfully.
- [x] **Docker Build:** Ran `docker compose up --build lattice` — kernel boots past the import stage without errors.
- [x] **Manual Verification:** Hit `GET /health/ready` → `200 OK`. Confirmed `GET /v1/blueprints` returns discovered blueprints.

## ✅ Checklist

- [ ] My code follows the project's style guidelines (Black/Ruff).
- [x] I have performed a self-review of my own code.
- [ ] I have commented hard-to-understand areas.
- [ ] I have updated the documentation (README, API docs) if needed.
- [x] My changes generate no new warnings.
- [ ] I have verified data persistence (Postgres/Redis) is not broken.
